### PR TITLE
IWF-836: SDK expects stateWaitUntilFailed flag instead stateStartApiSucceeded

### DIFF
--- a/.githooks/no-nexus.sh
+++ b/.githooks/no-nexus.sh
@@ -1,5 +1,11 @@
 #! /usr/bin/env bash
 
+# This script ensures that the poetry.lock file does not contain references to the internal Indeed Nexus PyPI repository.
+# It is used as a git hook to automatically remove the [package.source] section for Nexus from poetry.lock.
+# This is necessary to ensure the lock file is portable and open-source friendly.
+# The script uses gsed to remove the Nexus source block and any resulting empty lines, then checks if any changes were made.
+# If Nexus references are found and removed, the script exits with 1 to prevent the commit, so we can stage the changes made by the script before committing again.
+
 gsed -i'' \
     -e '/./{H;$!d}' \
     -e 'x' \

--- a/.githooks/no-nexus.sh
+++ b/.githooks/no-nexus.sh
@@ -1,16 +1,16 @@
 #! /usr/bin/env bash
 
-sed -i'' \
+gsed -i'' \
     -e '/./{H;$!d}' \
     -e 'x' \
     -e 's|\[package.source\]\ntype\s*=\s*\"legacy\"\nurl\s*=\s*\"https://nexus.corp.indeed.com/repository/pypi/simple\"\nreference\s*=\s*\"nexus\"||' \
     poetry.lock
 
-sed -i'' \
+gsed -i'' \
     -e '1{/^\s*$/d}' \
     poetry.lock
 
-sed -i'' \
+gsed -i'' \
     -e '/^\s*$/N;/^\s*\n$/D' \
     poetry.lock
 

--- a/.githooks/no-nexus.sh
+++ b/.githooks/no-nexus.sh
@@ -1,0 +1,23 @@
+#! /usr/bin/env bash
+
+sed -i'' \
+    -e '/./{H;$!d}' \
+    -e 'x' \
+    -e 's|\[package.source\]\ntype\s*=\s*\"legacy\"\nurl\s*=\s*\"https://nexus.corp.indeed.com/repository/pypi/simple\"\nreference\s*=\s*\"nexus\"||' \
+    poetry.lock
+
+sed -i'' \
+    -e '1{/^\s*$/d}' \
+    poetry.lock
+
+sed -i'' \
+    -e '/^\s*$/N;/^\s*\n$/D' \
+    poetry.lock
+
+CHANGES=$(git diff --exit-code poetry.lock | grep -Pzo '\-\[package.source\]\n\-type = "legacy"\n\-url = "https://nexus.corp.indeed.com/repository/pypi/simple"\n\-reference = "nexus"\n' | wc -c)
+
+if [[ $CHANGES -eq 0 ]]; then
+  exit 0
+fi
+
+exit 1

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -48,3 +48,9 @@ repos:
     pass_filenames: false
     args:
     - "iwf"
+
+  - id: no-nexus
+    name: Remove nexus references
+    entry: .githooks/no-nexus.sh
+    language: script
+    types: [file] # Example: run on all files, adjust as needed

--- a/iwf/iwf_api/models/command_results.py
+++ b/iwf/iwf_api/models/command_results.py
@@ -23,12 +23,14 @@ class CommandResults:
         inter_state_channel_results (Union[Unset, list['InterStateChannelResult']]):
         timer_results (Union[Unset, list['TimerResult']]):
         state_start_api_succeeded (Union[Unset, bool]):
+        state_wait_until_failed (Union[Unset, bool]):
     """
 
     signal_results: Union[Unset, list["SignalResult"]] = UNSET
     inter_state_channel_results: Union[Unset, list["InterStateChannelResult"]] = UNSET
     timer_results: Union[Unset, list["TimerResult"]] = UNSET
     state_start_api_succeeded: Union[Unset, bool] = UNSET
+    state_wait_until_failed: Union[Unset, bool] = UNSET
     additional_properties: dict[str, Any] = _attrs_field(init=False, factory=dict)
 
     def to_dict(self) -> dict[str, Any]:
@@ -55,6 +57,8 @@ class CommandResults:
 
         state_start_api_succeeded = self.state_start_api_succeeded
 
+        state_wait_until_failed = self.state_wait_until_failed
+
         field_dict: dict[str, Any] = {}
         field_dict.update(self.additional_properties)
         field_dict.update({})
@@ -66,6 +70,8 @@ class CommandResults:
             field_dict["timerResults"] = timer_results
         if state_start_api_succeeded is not UNSET:
             field_dict["stateStartApiSucceeded"] = state_start_api_succeeded
+        if state_wait_until_failed is not UNSET:
+            field_dict["stateWaitUntilFailed"] = state_wait_until_failed
 
         return field_dict
 
@@ -99,11 +105,14 @@ class CommandResults:
 
         state_start_api_succeeded = d.pop("stateStartApiSucceeded", UNSET)
 
+        state_wait_until_failed = d.pop("stateWaitUntilFailed", UNSET)
+
         command_results = cls(
             signal_results=signal_results,
             inter_state_channel_results=inter_state_channel_results,
             timer_results=timer_results,
             state_start_api_succeeded=state_start_api_succeeded,
+            state_wait_until_failed=state_wait_until_failed,
         )
 
         command_results.additional_properties = d


### PR DESCRIPTION
### Description
⚠️ Breaking change, requires iWF server version >= 1.18.0
SDK expects stateWaitUntilFailed flag instead stateStartApiSucceeded 

### Checklist
- [x] Code compiles correctly
- [x] Tests for the changes have been added
- [x] All tests passing
- [ ] **This PR change is backwards-compatible**
- [x] **This PR CONTAINS a (planned) breaking change** (it is NOT backwards-compatible)

### Related Issue
Addressing, but not yet closing https://github.com/indeedeng/iwf/issues/520, as we still need:
- Add changes for all SDKs
- Clean up old server fields (i.e. remove stateStartApiSucceeded field)